### PR TITLE
wrap-clojure-params - safely handle empty bodies

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -62,6 +62,12 @@
   (binding [*read-eval* false]
     (read-string str)))
 
+(defn parse-clojure-string [s]
+  "Decode a clojure body. The body is merged into the params, so must be a map or a vector of
+key value pairs. An empty body is safely handled."
+  (when (not (.isEmpty (.trim s)))
+    (safe-read-string s)))
+
 (def clojure-request?
   (make-type-request-pred #"^application/(vnd.+)?(x-)?clojure"))
 
@@ -69,7 +75,7 @@
   "Handles body params in Clojure format. See wrap-format-params for details."
   [handler & {:keys [predicate decoder charset]
               :or {predicate clojure-request?
-                   decoder safe-read-string
+                   decoder parse-clojure-string
                    charset get-charset}}]
   (wrap-format-params handler :predicate predicate :decoder decoder :charset charset))
 

--- a/test/ring/middleware/test/format_params.clj
+++ b/test/ring/middleware/test/format_params.clj
@@ -70,6 +70,22 @@
         (is false "Eval in reader permits arbitrary code execution."))
       (catch Exception ignored))))
 
+(deftest no-body-with-clojure-content-type
+  (let [req {:content-type "application/clojure; charset=UTF-8"
+             :body (stream "")
+             :params {"id" 3}}
+             resp (clojure-echo req)]
+    (is (= {"id" 3} (:params resp)))
+    (is (= nil (:body-params resp)))))
+
+(deftest whitespace-body-with-clojure-content-type
+  (let [req {:content-type "application/clojure; charset=UTF-8"
+             :body (stream "\t  ")
+             :params {"id" 3}}
+             resp (clojure-echo req)]
+    (is (= {"id" 3} (:params resp)))
+    (is (= nil (:body-params resp)))))
+
 (def restful-echo
   (wrap-restful-params identity))
 


### PR DESCRIPTION
This prevents wrap-restful-params from barfing when want to GET a clojure formatted response.
