### PR TITLE
JSON en/decoding using cheshire.custom.

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -1,5 +1,5 @@
 (ns ring.middleware.format-params
-  (:require [cheshire.core :as json]
+  (:require [cheshire.custom :as json]
             [clj-yaml.core :as yaml])
   (:import [com.ibm.icu.text CharsetDetector]))
 

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -1,5 +1,5 @@
 (ns ring.middleware.format-response
-  (:require [cheshire.core :as json]
+  (:require [cheshire.custom :as json]
             [ring.util.response :as res]
             [clojure.java.io :as io]
             [clj-yaml.core :as yaml]


### PR DESCRIPTION
This simplifies using custom encoders for types not directly
supported by Cheshire without sacrificing the generality of
the wrap-restful-\* functions.
