### PR TITLE
Don’t try to merge the body into `:params` if it’s not a map.

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -56,7 +56,8 @@
             fmt-params (decoder bstr)
             req* (assoc req
                    :body-params fmt-params
-                   :params (merge (:params req) fmt-params))]
+                   :params (merge (:params req)
+                                  (when (map? fmt-params) fmt-params)))]
         (handler req*))
       (handler req))))
 

--- a/test/ring/middleware/test/format_params.clj
+++ b/test/ring/middleware/test/format_params.clj
@@ -107,3 +107,11 @@
         resp (restful-echo req)]
     (is (= {"id" 3 :fée "böz"} (:params resp)))
     (is (= {:fée "böz"} (:body-params resp)))))
+
+(deftest test-list-body-request
+  (let [req {:content-type "application/json"
+             :body (ByteArrayInputStream.
+                    (.getBytes "[\"gregor\", \"samsa\"]"))}]
+    ((wrap-json-params
+      (fn [{:keys [body-params]}] (is (= ["gregor" "samsa"] body-params))))
+     req)))


### PR DESCRIPTION
The existing implementation of `wrap-format-params` always tries to merge `:body-params` into `:params`. However, when the request payload is a JSON list instead of a JSON object, this causes an `IllegalArgumentException`:

```
  actual: java.lang.IllegalArgumentException: Vector arg to map conj must be a pair
 at clojure.lang.APersistentMap.cons (APersistentMap.java:34)
    clojure.lang.RT.conj (RT.java:551)
    clojure.core$conj.invoke (core.clj:83)
    clojure.core$merge$fn__4155.invoke (core.clj:2631)
    clojure.core$reduce1.invoke (core.clj:880)
    clojure.core$reduce1.invoke (core.clj:871)
    clojure.core$merge.doInvoke (core.clj:2631)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    ring.middleware.format_params$wrap_format_params$fn__488.invoke (format_params.clj:59)
    ring.middleware.test.format_params/fn (format_params.clj:132)
```

This patch only merges if the payload is a map, and adds a test. This has bitten me a couple times, and I'd really like to see an updated release which fixes it.
