### PR TITLE
Handle optional :body of request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ pom.xml
 *jar
 /lib/
 /classes/
+/target
 .lein-failures
 .lein-deps-sum

--- a/test/ring/middleware/test/format_params.clj
+++ b/test/ring/middleware/test/format_params.clj
@@ -115,3 +115,9 @@
     ((wrap-json-params
       (fn [{:keys [body-params]}] (is (= ["gregor" "samsa"] body-params))))
      req)))
+
+(deftest test-optional-body
+  ((wrap-json-params
+    (fn [request]
+      (is (nil? (:body request)))))
+   {:body nil}))


### PR DESCRIPTION
Hi Nils,

the Ring SPEC says that the :body of a request is optional and
can be nil. This patch handles that case. Would you like to merge
this into master?

Roman.
