### PR TITLE
Custom EDN tags

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -158,7 +158,7 @@
   "Decode a clojure body. The body is merged into the params, so must be a map
    or a vector of key value pairs. An empty body is safely handled."
   (when-not (.isEmpty (.trim s))
-    (edn/read-string s)))
+    (edn/read-string {:readers *data-readers*} s)))
 
 (def clojure-request?
   (make-type-request-pred #"^application/(vnd.+)?(x-)?(clojure|edn)"))


### PR DESCRIPTION
Hi Nils,

I just noticed that custom tags defined in the data_readers.clj
file of an application are not handled by ring-middleware-format.

When a Clojure applications starts, tags defined in
data_readers.clj are loaded into the _data-readers_ dynamic var.
However, the default behaviour of edn/read-string is to care only
about the tags in default-data-readers.

Passing {:readers _data-readers_} as the first argument to
edn/read-string solves this.

Would you like to merge this into master?

Thanks, Roman.
