### PR TITLE
Fix wrap-format-params for CoyoteInputStream.

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -79,7 +79,7 @@
   [handler & {:keys [predicate decoder charset handle-error]}]
   (fn [{:keys [#^InputStream body] :as req}]
     (try
-      (if (and body (> (.available body) 0) (predicate req))
+      (if (and body (predicate req))
         (let [byts (slurp-to-bytes body)
               body (:body req)
               #^String char-enc (if (string? charset) charset (charset (assoc req :body byts)))


### PR DESCRIPTION
Hi Nils,

I'm running my Ring application inside Immutant/Tomcat. There the
call wrap-format-params fails because the (> (.available body) 0)
predicate is somehow false. The call to (.available body) on an
org.apache.catalina.connector.CoyoteInputStream returns 0. I'm
not sure if this is correct.

However, I looked at other middleware like ring-json. They don't
do such a check on the input stream and just slurp it. This patch
removes the (> (.available body) 0) check in order to get
ring-middleware-format working on Immutant/Tomcat.

Would you like to merge this into master and make a release?

Thanks, Roman.
