### PR TITLE
do not serialize when entire response is nil

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -10,11 +10,12 @@
 (defn serializable?
   "Predicate that returns true whenever the response body is not a
   String, File or InputStream."
-  [_ {:keys [body]}]
-  (not (or
-        (string? body)
-        (instance? File body)
-        (instance? InputStream body))))
+  [_ {:keys [body] :as response}]
+  (when response
+    (not (or
+          (string? body)
+          (instance? File body)
+          (instance? InputStream body)))))
 
 (defn can-encode?
   "Check whether encoder can encode to accepted-type.


### PR DESCRIPTION
It is my understanding that ring and compojure use a nil response to indicate that the request could not be handled, allowing multiple handlers to be chained together.

But `wrap-restful-response` prevents this by serializing the nil body in this case. What do think of checking if the entire response is nil in `serializable?` to fix this issue?
