### PR TITLE
Changed deprecated usage of cheshire.custom to cheshire.core

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -1,5 +1,5 @@
 (ns ring.middleware.format-params
-  (:require [cheshire.custom :as json]
+  (:require [cheshire.core :as json]
             [clj-yaml.core :as yaml]
             [clojure.tools.reader.edn :as edn])
   (:import [com.ibm.icu.text CharsetDetector]

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -1,5 +1,5 @@
 (ns ring.middleware.format-response
-  (:require [cheshire.custom :as json]
+  (:require [cheshire.core :as json]
             [ring.util.response :as res]
             [clojure.java.io :as io]
             [clj-yaml.core :as yaml]


### PR DESCRIPTION
Using deprecated cheshire.custom breaks interoperability with some libraries that register custom JSON encoders, for instance monger.
