### PR TITLE
HTML escape YAML in HTML

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,5 @@
                  [cheshire "5.2.0"]
                  [org.clojure/tools.reader "0.7.10"]
                  [com.ibm.icu/icu4j "52.1"]
-                 [clj-yaml "0.4.0"]])
+                 [clj-yaml "0.4.0"]
+                 [org.apache.commons/commons-lang3 "3.1"]])

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -196,7 +196,7 @@
   [body]
   (str
    "<html>\n<head></head>\n<body><div><pre>\n"
-   (yaml/generate-string body)
+   (org.apache.commons.lang3.StringEscapeUtils/escapeHtml4 (yaml/generate-string body))
    "</pre></div></body></html>"))
 
 (defn wrap-yaml-in-html-response

--- a/test/ring/middleware/test/format_response.clj
+++ b/test/ring/middleware/test/format_response.clj
@@ -59,6 +59,13 @@
     (is (.contains (get-in resp [:headers "Content-Type"]) "application/x-yaml"))
     (is (< 2 (Integer/parseInt (get-in resp [:headers "Content-Length"]))))))
 
+(deftest html-escape-yaml-in-html
+  (let [req {:body {:foo "<bar>"}}
+        resp ((wrap-yaml-in-html-response identity) req)
+        body (slurp (:body resp))]
+    (is (.contains body "&lt;"))
+    (is (.contains body "&gt;"))))
+
 (deftest can-encode?-accept-any-type
   (is (can-encode? {:enc-type {:type "foo" :sub-type "bar"}}
                    {:type "*" :sub-type "*"})))


### PR DESCRIPTION
Currently characters such as `<` and `>` are not displayed when viewing the `yaml-in-html` response body in a browser as they need to be HTML escaped.

I'd like to propose that the YAML string generated in `wrap-yaml-in-html` be HTML escaped so that all characters will display as expected. PR to follow.
