### PR TITLE
Fix transit with wrap-restful-response

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -257,7 +257,7 @@
    more details."
   [handler & {:keys [handle-error formats]
               :or {handle-error default-handle-error
-                   formats [:json :edn :yaml :transit-mspack :transit-json]}}]
+                   formats [:json :edn :yaml :transit-msgpack :transit-json]}}]
   (reduce (fn [h format]
             (if-let [wrapper (if
                               (fn? format) format

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -334,9 +334,9 @@
    :yaml (make-encoder yaml/generate-string "application/x-yaml")
    :yaml-kw (make-encoder yaml/generate-string "application/x-yaml")
    :yaml-in-html (make-encoder wrap-yaml-in-html "text/html")
-   :transit-json (make-encoder wrap-transit-json-response
+   :transit-json (make-encoder (make-transit-encoder :json {})
                                "application/transit+json" :binary)
-   :transit-msgpack (make-encoder wrap-transit-msgpack-response
+   :transit-msgpack (make-encoder (make-transit-encoder :msgpack {})
                                   "application/transit+msgpack" :binary)})
 
 (defn wrap-restful-response

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -189,6 +189,8 @@
     (doseq [accept ["application/edn"
                     "application/json"
                     "application/x-yaml"
+                    "application/transit+json"
+                    "application/transit+msgpack"
                     "text/html"]]
       (let [req {:body body :headers {"accept" accept}}
             resp (restful-echo req)]


### PR DESCRIPTION
Hi,

I noticed that transit encoding doesn't work with `wrap-restful-response`.

The reason is that for some reason `format-encoders` references `wrap-transjon-{json,msgpack}-response`-middleware. I changed the code to use `make-transit-encoder`.