### PR TITLE
Do not serialize nil response bodies

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -17,11 +17,12 @@
   (into #{} (map s/lower-case (.keySet (Charset/availableCharsets)))))
 
 (defn ^:no-doc serializable?
-  "Predicate that returns true whenever the response body is not a
+  "Predicate that returns true whenever the response body is non-nil, and not a
   String, File or InputStream."
   [_ {:keys [body] :as response}]
   (when response
     (not (or
+          (nil? body)
           (string? body)
           (instance? File body)
           (instance? InputStream body)))))

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -12,6 +12,17 @@
 (def json-echo
   (wrap-json-response identity))
 
+(deftest noop-with-nil
+  (let [body nil
+        req {:body body}
+        resp (json-echo req)]
+    (is (= nil (:body resp)))))
+
+(deftest noop-with-missing-body
+  (let [req {:status 200}
+        resp (json-echo req)]
+    (is (= nil (:body resp)))))
+
 (deftest noop-with-string
   (let [body "<xml></xml>"
         req {:body body}

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -175,11 +175,13 @@
                                               :sub-type "edn"}}]
                                  req)))))
 
+(defn echo-with-default-body [req] (assoc req :body (get req :body {})))
+
 (def restful-echo
-  (wrap-restful-response identity))
+  (wrap-restful-response echo-with-default-body))
 
 (def safe-restful-echo
-  (wrap-restful-response identity
+  (wrap-restful-response echo-with-default-body
                          :handle-error (fn [_ _ _] {:status 500})
                          :formats
                          [(make-encoder (fn [_] (throw (RuntimeException. "Memento mori")))

--- a/test/ring/middleware/format_test.clj
+++ b/test/ring/middleware/format_test.clj
@@ -8,15 +8,17 @@
 (defn stream [s]
   (ByteArrayInputStream. (.getBytes s "UTF-8")))
 
+(defn body-param-vals [req] (or (vals (:body-params req)) []))
+
 (def restful-echo
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))))
+  (wrap-restful-format (fn [req] (assoc req :body (body-param-vals req)))))
 
 (def restful-echo-json
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
+  (wrap-restful-format (fn [req] (assoc req :body (body-param-vals req)))
                        :formats [:json-kw]))
 
 (def restful-echo-yaml
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
+  (wrap-restful-format (fn [req] (assoc req :body (body-param-vals req)))
                        :formats [:yaml-kw]))
 
 (deftest test-restful-round-trip


### PR DESCRIPTION
Hey @ngrunwald. Thanks for creating this middleware and for maintaining it. It's very convenient being able to keep handlers concise by eliminating the encoding boilerplate.

One issue that came up for me using `wrap-restful-format` is that it changes the ring behaviour for responses with a nil `:body` or missing `:body`. I can appreciate that it's possible that folks might want a response of `{:status 500}` to be coerced to a JSON response with a body of `null`. For me, the least surprising behaviour is an empty response body.

What do you think?

The fundamental change in this Pull Request is to [treat `nil` as non-serializable](https://github.com/curious-attempt-bunny/ring-middleware-format/commit/9833c4a492f54f7464fe584e3565422c9cd2b193).