### PR TITLE
Multiple changes from Metosin fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
-lein: lein2
+sudo: false
 language: clojure
+lein: lein2
+script: lein2 do clean, all test, all check
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk8
+cache:
+  directories:
+  - $HOME/.m2

--- a/project.clj
+++ b/project.clj
@@ -18,4 +18,6 @@
   :plugins [[codox "0.8.11"]]
   :codox {:src-dir-uri "http://github.com/ngrunwald/ring-middleware-format/blob/master/"
           :src-linenum-anchor-prefix "L"
-          :defaults {:doc/format :markdown}})
+          :defaults {:doc/format :markdown}}
+  :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0-beta2"]]}}
+  :aliases {"all" ["with-profile" "dev:dev,1.7"]})

--- a/src/ring/middleware/format.clj
+++ b/src/ring/middleware/format.clj
@@ -13,8 +13,10 @@
    use keywords as keys when deserializing. The first format is also
    the default serialization format (*:json* by default). You can also
    specify error-handlers for the params parsing with *:request-error-handler*
-   or the response encoding with *:response-error-handler*. See
-   [[ring.middleware.format-params/wrap-format-params]] and
+   or the response encoding with *:response-error-handler*.
+   Format options can be passed to responding middlewares using *:response-opts*
+   and *:params-opts*.
+   See [[ring.middleware.format-params/wrap-format-params]] and
    [[ring.middleware.format-response/wrap-format-response]] for details"
   [handler & {:keys [formats response-error-handler request-error-handler response-opts params-opts]
               :or {formats [:json :edn :yaml :yaml-in-html

--- a/src/ring/middleware/format.clj
+++ b/src/ring/middleware/format.clj
@@ -16,12 +16,11 @@
    or the response encoding with *:response-error-handler*. See
    [[ring.middleware.format-params/wrap-format-params]] and
    [[ring.middleware.format-response/wrap-format-response]] for details"
-  [handler & {:keys [formats response-error-handler request-error-handler]
+  [handler & {:keys [formats response-error-handler request-error-handler response-opts params-opts]
               :or {formats [:json :edn :yaml :yaml-in-html
                             :transit-msgpack :transit-json]
                    response-error-handler res/default-handle-error
-                   request-error-handler par/default-handle-error}
-              :as options}]
+                   request-error-handler par/default-handle-error}}]
   (-> handler
-      (par/wrap-restful-params :formats formats :handle-error request-error-handler)
-      (res/wrap-restful-response :formats formats :handle-error response-error-handler)))
+      (par/wrap-restful-params :formats formats :handle-error request-error-handler :format-options params-opts)
+      (res/wrap-restful-response :formats formats :handle-error response-error-handler :format-options response-opts)))

--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -253,13 +253,13 @@
    a solid basis for a RESTful API. It will deserialize to *JSON*, *YAML*, *Transit*
    or *Clojure* depending on Content-Type header. See [[wrap-format-params]] for
    more details."
-  [handler & {:keys [handle-error formats]
+  [handler & {:keys [handle-error formats format-options]
               :or {handle-error default-handle-error
                    formats [:json :edn :yaml :transit-msgpack :transit-json]}}]
   (reduce (fn [h format]
             (if-let [wrapper (if
                               (fn? format) format
                               (format-wrappers (keyword format)))]
-              (wrapper h :handle-error handle-error)
+              (wrapper h :handle-error handle-error :options (get format-options format))
               h))
           handler formats))

--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -252,7 +252,9 @@
   "Wrapper that tries to do the right thing with the request :body and provide
    a solid basis for a RESTful API. It will deserialize to *JSON*, *YAML*, *Transit*
    or *Clojure* depending on Content-Type header. See [[wrap-format-params]] for
-   more details."
+   more details.
+   Options to specific format decoders can be passed in using *:format-options*
+   option. If should be map of format keyword to options map."
   [handler & {:keys [handle-error formats format-options]
               :or {handle-error default-handle-error
                    formats [:json :edn :yaml :transit-msgpack :transit-json]}}]

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -348,8 +348,9 @@
   See wrap-format-response for more details. Recognized formats are
   *:json*, *:json-kw*, *:edn* *:yaml*, *:yaml-in-html*, *:transit-json*,
   *:transit-msgpack*."
-  [handler & {:keys [handle-error formats charset binary?]
+  [handler & {:keys [predicate handle-error formats charset binary?]
               :or {handle-error default-handle-error
+                   predicate serializable?
                    charset default-charset-extractor
                    formats [:json :yaml :edn :clojure :yaml-in-html :transit-json :transit-msgpack]}}]
   (let [encoders (for [format formats
@@ -360,7 +361,7 @@
                        :when encoder]
                    encoder)]
     (wrap-format-response handler
-                          :predicate serializable?
+                          :predicate predicate
                           :encoders encoders
                           :binary? binary?
                           :charset charset

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -127,7 +127,9 @@
   ([encoder content-type binary?]
      {:encoder encoder
       :enc-type (first (parse-accept-header content-type))
-      :binary? binary?})
+      :binary? binary?
+      ;; Include content-type to allow later introspection of encoders.
+      :content-type content-type})
   ([encoder content-type]
      (make-encoder encoder content-type false)))
 

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -354,7 +354,9 @@
   JSON, YAML, Clojure, Transit or HTML-wrapped YAML depending on Accept header.
   See wrap-format-response for more details. Recognized formats are
   *:json*, *:json-kw*, *:edn* *:yaml*, *:yaml-in-html*, *:transit-json*,
-  *:transit-msgpack*."
+  *:transit-msgpack*.
+  Options to specific encoders can be passed in using *:format-options*
+  option. If is a map from format keyword to options map."
   [handler & {:keys [predicate handle-error formats charset binary? format-options]
               :or {handle-error default-handle-error
                    predicate serializable?

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -336,10 +336,15 @@
    :yaml (make-encoder yaml/generate-string "application/x-yaml")
    :yaml-kw (make-encoder yaml/generate-string "application/x-yaml")
    :yaml-in-html (make-encoder wrap-yaml-in-html "text/html")
-   :transit-json (make-encoder (make-transit-encoder :json {})
-                               "application/transit+json" :binary)
-   :transit-msgpack (make-encoder (make-transit-encoder :msgpack {})
-                                  "application/transit+msgpack" :binary)})
+   :transit-json (assoc (make-encoder nil "application/transit+json" :binary)
+                   :encoder-fn #(make-transit-encoder :json %))
+   :transit-msgpack (assoc (make-encoder nil "application/transit+msgpack" :binary)
+                      :encoder-fn #(make-transit-encoder :msgpack %))})
+
+(defn init-encoder [encoder opts]
+  (if-let [init (:encoder-fn encoder)]
+    (assoc encoder :encoder (init opts))
+    encoder))
 
 (defn wrap-restful-response
   "Wrapper that tries to do the right thing with the response *:body*
@@ -348,7 +353,7 @@
   See wrap-format-response for more details. Recognized formats are
   *:json*, *:json-kw*, *:edn* *:yaml*, *:yaml-in-html*, *:transit-json*,
   *:transit-msgpack*."
-  [handler & {:keys [predicate handle-error formats charset binary?]
+  [handler & {:keys [predicate handle-error formats charset binary? format-options]
               :or {handle-error default-handle-error
                    predicate serializable?
                    charset default-charset-extractor
@@ -357,7 +362,7 @@
                        :when format
                        :let [encoder (if (map? format)
                                        format
-                                       (get format-encoders (keyword format)))]
+                                       (init-encoder (get format-encoders (keyword format)) (get format-options (keyword format))))]
                        :when encoder]
                    encoder)]
     (wrap-format-response handler

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -226,3 +226,14 @@
     (is (= "application/json; charset=utf-8" (get-in resp [:headers "Content-Type"])))
     (is (= "0" (get-in resp [:headers "Content-Length"])))
     (is (nil? (:body resp)))))
+
+(def restful-echo-pred
+  (wrap-restful-response identity :predicate (fn [_ resp]
+                                               (::serializable? resp))))
+
+(deftest custom-predicate
+  (let [req {:body {:foo "bar"}}
+        resp-non-serialized (restful-echo-pred (assoc req ::serializable? false))
+        resp-serialized     (restful-echo-pred (assoc req ::serializable? true))]
+    (is (map? (:body resp-non-serialized)))
+    (is (instance? java.io.BufferedInputStream (:body resp-serialized)))))


### PR DESCRIPTION
Hi,

I had finally time to check what changes our fork still has which have not been merged here. With a bit of git sorcery I managed to reduce commits to only a handful. I also did rewrite some code to be non-breaking.

Quick list of changes:
- Some Travis changes to run tests on several platforms
- Added predicate option to `wrap-restful-response`
- Made it possible to set options for transit writer and reader through `wrap-restful-*` middlewares using `:format-options` option.
- Tests for previous option & Custom transit handlers.
- `make-encoder` saves the original content-type to resulting map for later introspection