### PR TITLE
Upgrade clj-yaml to version 0.5.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/core.memoize "0.5.7"]
                  [ring/ring-core "1.4.0"]
                  [cheshire "5.5.0"]
-                 [org.clojure/tools.reader "0.9.2"]
+                 [org.clojure/tools.reader "0.10.0-alpha3"]
                  [com.ibm.icu/icu4j "55.1"]
                  [circleci/clj-yaml "0.5.3"]
                  [clojure-msgpack "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [cheshire "5.5.0"]
                  [org.clojure/tools.reader "0.9.2"]
                  [com.ibm.icu/icu4j "55.1"]
-                 [clj-yaml "0.4.0"]
+                 [circleci/clj-yaml "0.5.3"]
                  [clojure-msgpack "1.1.1"]
                  [com.cognitect/transit-clj "0.8.281"]]
   :plugins [[codox "0.8.11"]]

--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -190,10 +190,9 @@
    See [[wrap-format-params]] for details."
   [handler & args]
   (let [{:keys [predicate decoder] :as options} (impl/extract-options args)]
-    (binding [clj-yaml.core/*keywordize* true]
-      (wrap-format-params handler (assoc options
-                                         :predicate (or predicate yaml-request?)
-                                         :decoder (or decoder yaml/parse-string))))))
+    (wrap-format-params handler (assoc options
+                                       :predicate (or predicate yaml-request?)
+                                       :decoder (or decoder yaml/parse-string)))))
 
 (defn parse-clojure-string
   "Decode a clojure body. The body is merged into the params, so must be a map


### PR DESCRIPTION
I detected a conflict between `ring-middleware-format` and [uap-clj](https://github.com/russellwhitaker/uap-clj), which uses the [forked version 0.5.3](https://github.com/circleci/clj-yaml) of `clj-yaml`.

Upgrading to this version of `clj-yaml` is fairly easy (keywordize is true by default as seen [here](https://github.com/circleci/clj-yaml/blob/master/src/clojure/clj_yaml/core.clj#L119)) and also allows to get rid of the not-very-elegant `binding` that was mandatory when using version `0.4.0`.