### PR TITLE
allow passing response-predicate to wrap-restful-format

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -175,10 +175,10 @@
  + **:handle-error** is a fn with a sig [exception request response]. Defaults
                      to just rethrowing the Exception"
   [handler & args]
-  (let [{:keys [predicate encoders charset binary? handle-error]} (impl/extract-options args)
+  (let [{:keys [response-predicate predicate encoders charset binary? handle-error]} (impl/extract-options args)
         charset (or charset default-charset-extractor)
         handle-error (or handle-error default-handle-error)
-        predicate (or predicate serializable?)]
+        predicate (or response-predicate predicate serializable?)]
     (fn [req]
       (let [{:keys [headers body] :as response} (handler req)]
         (try


### PR DESCRIPTION
I'm not sure if this is the best fix for it, but right now, there is no way to pass `:predicate` to `wrap-restful-format`, because it ends up getting passed to both `wrap-restful-params` and `wrap-restful-response`, which doesn't work.

In my case, I only need to pass a predicate to `wrap-restful-response`, so I made that `wrap-format-response` accept `:response-predicate` and prefer that over `:predicate`.

There's probably a better way to solve this issue. I'm open to suggestions.