### PR TITLE
Overriding json pretty-printing with passed-in options by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Please note the default JSON, MessagePack, and YAML decoder do not keywordize th
 
 See also [wrap-restful-format](http://ngrunwald.github.com/ring-middleware-format/ring.middleware.format.html#var-wrap-restful-format) docstring for help on customizing error handling.
 
+It is possible to configure the behavior of various decoders by passing `:response-options` 
+or `:params-options` parameters to `(wrap-restful-format)`; these options are structured as 
+a map from the type of decoder to the options to use for that format. For example, to pretty-print 
+JSON responses these options could be used:
+```clojure
+(wrap-restful-format handler :formats [:json-kw] :response-options {:json-kw {:pretty true}})
+```
+
 ## Usage ##
 
 ### Detailed Usage ###

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -205,7 +205,7 @@
             (handle-error e req response)))))))
 
 (defn make-json-encoder [pretty options]
-  (let [opts (assoc options :pretty pretty)]
+  (let [opts (merge {:pretty pretty} options)]
     (fn [s]
       (json/generate-string s opts))))
 

--- a/test/ring/middleware/format_test.clj
+++ b/test/ring/middleware/format_test.clj
@@ -22,6 +22,15 @@
   (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
                        :formats [:yaml-kw]))
 
+(deftest format-json-prettily-from-wrap-restful-format
+  ;; like format-response-test/format-json-prettily but starting from higher in the call stack
+  (let [body {:foo "bar"}
+        req {:body body}
+        resp ((wrap-restful-format identity :formats [:json-kw]
+                                            :response-options {:json-kw {:pretty true}})
+               req)]
+    (is (.contains (-> resp :body slurp) "\n "))))
+
 (deftest test-restful-round-trip
   (let [ok-accept "application/edn"
         msg {:test :ok}


### PR DESCRIPTION
Fix for #61. I added in a brief example in the README and added a test - there was an existing test for testing the pretty-printing options, but the bug existed a little higher up in the call stack so it hadn't been exposed previously. Being somewhat lazy, I mostly just copied that test.