### PR TITLE
Fix for reflection warning: "call to method setText on CharsetDetector can't be resolved"

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -18,11 +18,11 @@
   (into #{} (map str/lower-case (.keySet (Charset/availableCharsets)))))
 
 (defn ^:no-doc guess-charset
-  [{:keys [#^bytes body]}]
+  [{:keys [body]}]
   (try
     (let [#^CharsetDetector detector (CharsetDetector.)]
       (.enableInputFilter detector true)
-      (.setText detector body)
+      (.setText detector #^bytes body)
       (let [m (.detect detector)
             encoding (.getName m)]
         (if (available-charsets encoding)


### PR DESCRIPTION
I was originally going to file a ticket on this, but the fix seemed pretty easy so here is a PR instead.

This is a fix for the following message, which I am seeing printed to stdout when my application starts up:

```
Reflection warning, ring/middleware/format_params.clj:25:7 - call to method setText on com.ibm.icu.text.CharsetDetector can't be resolved (argument types: java.lang.Object).
```

I'm running `[ring-middleware-format "0.7.0"]` and `[org.clojure/clojure "1.9.0-alpha10"]` with `Leiningen 2.7.0 on Java 1.8.0_45 Java HotSpot(TM) 64-Bit Server VM`. 

When I run with this patch applied I no longer see the warning.

I'm not really sure why this change fixes the issue; googling around a little bit did turn up [an ancient bug](http://dev.clojure.org/jira/browse/CLJ-887) about primitive type-hinting and destructuring args, but it doesn't look directly related to this. I also don't know of a good way to test this.
