### PR TITLE
Choose highest priority charset in accept header

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -117,6 +117,7 @@
   [charsets]
   (or
    (->> (sort-by second charsets)
+        (reverse)
         (filter (comp available-charsets first))
         (first)
         (first))

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -43,7 +43,7 @@
 
 (deftest returns-correct-charset
   (let [body {:foo "bârçï"}
-        req {:body body :headers {"accept-charset" "utf8; q=0.8 , utf-16"}}
+        req {:body body :headers {"accept-charset" "utf-8; q=0.8 , utf-16"}}
         resp ((wrap-json-response identity) req)]
     (is (.contains (get-in resp [:headers "Content-Type"]) "utf-16"))
     (is (= 32 (Integer/parseInt (get-in resp [:headers "Content-Length"]))))))


### PR DESCRIPTION
The current implementation uses the lowest priority charset.

Change the returns-correct-charset test to use `utf-8` rather than
`utf8` becuase the second (at least on my system) is filtered out as a
charset that isn't available.