### PR TITLE
Feature/fix parse accept header

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -82,7 +82,7 @@
                                    {}
                                    r))
                     (update-in [:q] #(or % 1.0)))))
-            (s/split accept-header #"[\s\n\r]*,[\s\n\r]"))
+            (s/split accept-header #"[\s\n\r]*,[\s\n\r]*"))
        (sort-by-check :type "*")
        (sort-by-check :sub-type "*")
        (sort-by :q >)))

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -68,24 +68,24 @@
   => ({:type \"application\" :sub-type \"json\"
        :q 0.4 :level \"1\"})"
   [accept-header]
-  (->> (map (fn [fragment]
-              (let [[media-range & r] (s/split fragment #"\s*;\s*")
-                    [type sub-type :as f] (rest (re-matches accept-fragment-re media-range))]
-                (-> {:type type
-                     :sub-type sub-type}
-                    (merge (reduce (fn [m s]
-                                     (if-let [[k v] (seq (rest (re-matches accept-fragment-param-re s)))]
-                                       (if (= "q" k)
-                                         (update-in m [:q] #(or % (parse-q v)))
-                                         (assoc m (keyword k) v))
-                                       m))
-                                   {}
-                                   r))
-                    (update-in [:q] #(or % 1.0)))))
-            (s/split accept-header #"[\s\n\r]*,[\s\n\r]*"))
-       (sort-by-check :type "*")
-       (sort-by-check :sub-type "*")
-       (sort-by :q >)))
+  (if accept-header
+    (->> (map (fn [fragment]
+                (let [[media-range & params-list] (s/split fragment #"\s*;\s*")
+                      [type sub-type] (rest (re-matches accept-fragment-re media-range))]
+                  (-> (reduce (fn [m s]
+                                (if-let [[k v] (seq (rest (re-matches accept-fragment-param-re s)))]
+                                  (if (= "q" k)
+                                    (update-in m [:q] #(or % (parse-q v)))
+                                    (assoc m (keyword k) v))
+                                  m))
+                              {:type type
+                               :sub-type sub-type}
+                              params-list)
+                      (update-in [:q] #(or % 1.0)))))
+              (s/split accept-header #"[\s\n\r]*,[\s\n\r]*"))
+         (sort-by-check :type "*")
+         (sort-by-check :sub-type "*")
+         (sort-by :q >))))
 
 (def parse-accept-header
   "Memoized form of [[parse-accept-header*]]"

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -199,7 +199,7 @@
              (parse-accept-header* "text/*;x=\"0.0=x\""))))))
 
 (deftest orders-values-correctly
-  (let [accept "text/plain, */*, text/plain;level=1, text/*, text/*;q=0.1"]
+  (let [accept "text/plain,*/*,text/plain;level=1, text/*, text/*;q=0.1"]
     (is (= (parse-accept-header accept)
            (list {:type "text"
                   :sub-type "plain"


### PR DESCRIPTION
Fixes #66 

`preferred-encoder` shouldn't use `(:content-type req)` (deprecated Ring request property) if Accept header is not present.

But `parse-accept-header` shouldn't throw exceptions if invalid value is found.

This change adds new tests which previously didn't work and reworks `parse-accept-header`.
