### PR TITLE
updated deps for clj-yaml version number

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [cheshire "5.7.0"]
                  [org.clojure/tools.reader "0.10.0"]
                  [com.ibm.icu/icu4j "58.2"]
-                 [circleci/clj-yaml "0.5.5"]
+                 [circleci/clj-yaml "0.5.6"]
                  [clojure-msgpack "1.2.0"]
                  [com.cognitect/transit-clj "0.8.297"]]
   :plugins [[lein-codox "0.10.2"]]


### PR DESCRIPTION
It looks like the the clj-yaml version has been updated.

 https://github.com/circleci/clj-yaml 

Though I don't know if it's live on clojars yet.  This will fix the break for updates to java 11