### PR TITLE
Update yaml

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [cheshire "5.8.1"]
                  [org.clojure/tools.reader "1.3.2"]
                  [com.ibm.icu/icu4j "63.1"]
-                 [circleci/clj-yaml "0.6.0"]
+                 [clj-commons/clj-yaml "0.6.0"]
                  [clojure-msgpack "1.2.1"]
                  [com.cognitect/transit-clj "0.8.313"]]
   :plugins [[lein-codox "0.10.2"]]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [cheshire "5.7.0"]
                  [org.clojure/tools.reader "0.10.0"]
                  [com.ibm.icu/icu4j "58.2"]
-                 [circleci/clj-yaml "0.5.6"]
+                 [circleci/clj-yaml "0.6.0"]
                  [clojure-msgpack "1.2.0"]
                  [com.cognitect/transit-clj "0.8.297"]]
   :plugins [[lein-codox "0.10.2"]]


### PR DESCRIPTION
clj-yaml was updated to use the correct version or ordered/flatland.  This should fix the java 11 upgrade issue