### PR TITLE
Remove icu4j dependency, add optional namespace with charset detection code

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,9 +4,14 @@
 
 **[compare](https://github.com/ngrunwald/ring-middleware-format/compare/0.7.3...master)**
 
-- Allow use without icu4j, if guess charset is not used
-    - Add `:charset get-or-default-charset` option to disable charset guessing
-    - Icu4j is still dependency, but you can use exclude
+- Drop dependency on Icu4j and default to no charset detection
+   - Previously ring-middleware-format tried to guess the charset if the request
+   `Content-Type` header didn't set it. **However** the charset detection code
+   has been broken since version 0.4.0, for over four years.
+   - Because no one has noticed during four years that charset detection doesn't work,
+   it is now disabled by default.
+   - Separate `guess-charset` namespace can be used with `:charset` option to
+   enable charset detection (which now works).
 
 ## 0.7.3 (2019-01-14)
 

--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
+**[compare](https://github.com/ngrunwald/ring-middleware-format/compare/0.7.3...master)**
+
+- Allow use without icu4j, if guess charset is not used
+    - Add `:charset get-or-default-charset` option to disable charset guessing
+    - Icu4j is still dependency, but you can use exclude
+
+## 0.7.3 (2019-01-14)
+
 **[compare](https://github.com/ngrunwald/ring-middleware-format/compare/0.7.2...0.7.3)**
+
 - Add support for Java 11
 - Dropped support for Java 6 and 7
 - Updated deps:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ For exemple, this will cause all json formatted responses to be encoded in *iso-
 ```
 + You can implement the wrapper from scratch by using either or both `wrap-format-params` and `wrap-format-response`. For now, see the docs of each and how the other formats were implemented for help doing this.
 
+### IBM Icu4j
+
+Icu4j is used to guess request charset if the request Content-type header doesn't
+define charset, and middleware `:charset` option hasn't been used to set static charset.
+
+If you don't want to use this feature, and want to remove the large Icu4j dependency,
+you can set middleware `:charset` option to alternative function, which will default
+to UTF-8 if Content-type header doesn't have charset:
+
+```clj
+(wrap-restful-params ... {:charset get-or-default-charset})
+```
+
+(You can also create your own functions if you need other default charsets.)
+
+And then you can exclude Icu4j dependency:
+
+```clj
+[ring-middleware-formats "a.b.c" :exclusions [com.ibm.icu/icu4j]]
+```
+
 ## Future Work ##
 
 ## See Also ##

--- a/README.md
+++ b/README.md
@@ -132,25 +132,27 @@ For exemple, this will cause all json formatted responses to be encoded in *iso-
 ```
 + You can implement the wrapper from scratch by using either or both `wrap-format-params` and `wrap-format-response`. For now, see the docs of each and how the other formats were implemented for help doing this.
 
-### IBM Icu4j
+### Charset detection
 
-Icu4j is used to guess request charset if the request Content-type header doesn't
+Icu4j can be used to guess request charset for requests where Content-type header doesn't
 define charset, and middleware `:charset` option hasn't been used to set static charset.
-
-If you don't want to use this feature, and want to remove the large Icu4j dependency,
-you can set middleware `:charset` option to alternative function, which will default
-to UTF-8 if Content-type header doesn't have charset:
+To use this feature, add dependency:
 
 ```clj
-(wrap-restful-params ... {:charset get-or-default-charset})
+[com.ibm.icu/icu4j "63.1"]
 ```
 
-(You can also create your own functions if you need other default charsets.)
+Note that icu4j is quite large dependency and will increase your uberjar size by 10MB.
 
-And then you can exclude Icu4j dependency:
+And require separate `guess-charset` namespace which provides function you can use
+with wrap-params `:charset` option:
 
 ```clj
-[ring-middleware-formats "a.b.c" :exclusions [com.ibm.icu/icu4j]]
+(ns example
+  (:require [ring.middleware.format-params.guess-charset :as guess-charset]
+            ...))
+
+(wrap-restful-params ... {:charset guess-charset/get-or-default-charset})
 ```
 
 ## Future Work ##

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-middleware-format "0.7.3"
+(defproject ring-middleware-format "0.7.4-SNAPSHOT"
   :description "Ring middleware for parsing parameters and emitting
   responses in various formats (mainly JSON, YAML and Transit out of
   the box)"

--- a/project.clj
+++ b/project.clj
@@ -11,16 +11,19 @@
                  [ring/ring-core "1.7.1"]
                  [cheshire "5.8.1"]
                  [org.clojure/tools.reader "1.3.2"]
-                 [com.ibm.icu/icu4j "63.1"]
                  [clj-commons/clj-yaml "0.6.0"]
                  [clojure-msgpack "1.2.1"]
                  [com.cognitect/transit-clj "0.8.313"]]
   :plugins [[lein-codox "0.10.2"]]
   :codox {:src-uri "http://github.com/ngrunwald/ring-middleware-format/blob/master/{filepath}#L{line}"
           :defaults {:doc/format :markdown}}
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}
+  ;; Include :icu profile for all tasks, except if with-profile is used without "+"
+  :profiles {:default [:base :system :user :provided :dev :icu]
+             ;; leaky metadata to include this dep in pom.xml
+             :icu ^:leaky {:dependencies [[com.ibm.icu/icu4j "63.1"]]}
+             :dev {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.6:dev,1.7:dev,1.8:dev,1.10"]})
+  :aliases {"all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.10:-icu"]})

--- a/project.clj
+++ b/project.clj
@@ -17,13 +17,10 @@
   :plugins [[lein-codox "0.10.2"]]
   :codox {:src-uri "http://github.com/ngrunwald/ring-middleware-format/blob/master/{filepath}#L{line}"
           :defaults {:doc/format :markdown}}
-  ;; Include :icu profile for all tasks, except if with-profile is used without "+"
-  :profiles {:default [:base :system :user :provided :dev :icu]
-             ;; leaky metadata to include this dep in pom.xml
-             :icu ^:leaky {:dependencies [[com.ibm.icu/icu4j "63.1"]]}
+  :profiles {:icu {:dependencies [[com.ibm.icu/icu4j "63.1"]]}
              :dev {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}}
-  :aliases {"all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.10:-icu"]})
+  :aliases {"all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.10:+icu"]})

--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -7,30 +7,14 @@
             [clojure.walk :refer [keywordize-keys]]
             [cognitect.transit :as transit]
             [msgpack.core :as msgpack])
-  (:import [java.io ByteArrayInputStream InputStream ByteArrayOutputStream]
-           [java.nio.charset Charset]))
+  (:import [java.io ByteArrayInputStream InputStream ByteArrayOutputStream]))
 
 (set! *warn-on-reflection* true)
-
-(def available-charsets
-  "Set of recognised charsets by the current JVM"
-  (into #{} (map str/lower-case (.keySet (Charset/availableCharsets)))))
 
 (defn ^:no-doc get-charset
   [{:keys [content-type] :as req}]
   (if content-type
     (second (re-find #";\s*charset=([^\s;]+)" content-type))))
-
-(defn get-or-guess-charset
-  "Tries to get the request encoding from the header or guess
-  it if not given in *Content-Type*. Defaults to *utf-8*"
-  [req]
-  ;; TODO: Does require + resolve affect performance?
-  (require 'ring.middleware.format-params.guess-charset)
-  (or
-   (get-charset req)
-   ((resolve 'ring.middleware.format-params.guess-charset/guess-charset) req)
-   "utf-8"))
 
 (defn ^:no-doc get-or-default-charset
   [req]
@@ -85,7 +69,7 @@
                      to just rethrowing the Exception"
   [handler & args]
   (let [{:keys [predicate decoder charset handle-error binary?] :as options} (impl/extract-options args)
-        charset (or charset get-or-guess-charset)
+        charset (or charset get-or-default-charset)
         handle-error (or handle-error default-handle-error)]
     (fn [{:keys [#^InputStream body] :as req}]
       (try

--- a/src/ring/middleware/format_params/guess_charset.clj
+++ b/src/ring/middleware/format_params/guess_charset.clj
@@ -1,5 +1,8 @@
 (ns ring.middleware.format-params.guess-charset
-  (:require [clojure.string :as str])
+  "Add dependency on com.ibm.icu/icu4j to your project to use
+  this namespace."
+  (:require [clojure.string :as str]
+            [ring.middleware.format-params :refer [get-charset]])
   (:import [com.ibm.icu.text CharsetDetector]
            [java.nio.charset Charset]))
 
@@ -13,6 +16,18 @@
       (.setText detector body)
       (let [m (.detect detector)
             encoding (.getName m)]
-        (if (Charset/forName encoding)
+        (if (try (Charset/forName encoding)
+                 true
+                 (catch java.nio.charset.UnsupportedCharsetException _
+                   false))
           encoding)))
     (catch Exception _ nil)))
+
+(defn get-or-guess-charset
+  "Tries to get the request encoding from the header or guess
+  it if not given in *Content-Type*. Defaults to *utf-8*"
+  [req]
+  (or
+   (get-charset req)
+   (guess-charset req)
+   "utf-8"))

--- a/src/ring/middleware/format_params/guess_charset.clj
+++ b/src/ring/middleware/format_params/guess_charset.clj
@@ -1,0 +1,18 @@
+(ns ring.middleware.format-params.guess-charset
+  (:require [clojure.string :as str])
+  (:import [com.ibm.icu.text CharsetDetector]
+           [java.nio.charset Charset]))
+
+(set! *warn-on-reflection* true)
+
+(defn ^:no-doc guess-charset
+  [{:keys [#^bytes body]}]
+  (try
+    (let [detector (CharsetDetector.)]
+      (.enableInputFilter detector true)
+      (.setText detector body)
+      (let [m (.detect detector)
+            encoding (.getName m)]
+        (if (Charset/forName encoding)
+          encoding)))
+    (catch Exception _ nil)))

--- a/test/ring/middleware/format_test.clj
+++ b/test/ring/middleware/format_test.clj
@@ -2,38 +2,32 @@
   (:use [clojure.test]
         [ring.middleware.format])
   (:require [cheshire.core :as json]
-            [clj-yaml.core :as yaml]
-            [ring.middleware.format-params :refer [get-or-default-charset]])
+            [clj-yaml.core :as yaml])
   (:import [java.io ByteArrayInputStream]))
 
 (defn stream [s]
   (ByteArrayInputStream. (.getBytes s "UTF-8")))
 
 (def restful-echo
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       {:charset get-or-default-charset}))
+  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))))
 
 (def restful-echo-opts-map
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       {:charset get-or-default-charset}))
+  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))))
 
 (def restful-echo-json
   (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       {:formats [:json-kw]
-                        :charset get-or-default-charset}))
+                       :formats [:json-kw]))
 
 (def restful-echo-yaml
   (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       {:formats [:yaml-kw]
-                        :charset get-or-default-charset}))
+                       :formats [:yaml-kw]))
 
 (deftest format-json-prettily-from-wrap-restful-format
   ;; like format-response-test/format-json-prettily but starting from higher in the call stack
   (let [body {:foo "bar"}
         req {:body body}
-        resp ((wrap-restful-format identity {:formats [:json-kw]
-                                             :response-options {:json-kw {:pretty true}}
-                                             :charset get-or-default-charset})
+        resp ((wrap-restful-format identity :formats [:json-kw]
+                                            :response-options {:json-kw {:pretty true}})
                req)]
     (is (.contains (-> resp :body slurp) "\n "))))
 

--- a/test/ring/middleware/format_test.clj
+++ b/test/ring/middleware/format_test.clj
@@ -2,32 +2,38 @@
   (:use [clojure.test]
         [ring.middleware.format])
   (:require [cheshire.core :as json]
-            [clj-yaml.core :as yaml])
+            [clj-yaml.core :as yaml]
+            [ring.middleware.format-params :refer [get-or-default-charset]])
   (:import [java.io ByteArrayInputStream]))
 
 (defn stream [s]
   (ByteArrayInputStream. (.getBytes s "UTF-8")))
 
 (def restful-echo
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))))
+  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
+                       {:charset get-or-default-charset}))
 
 (def restful-echo-opts-map
-  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))))
+  (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
+                       {:charset get-or-default-charset}))
 
 (def restful-echo-json
   (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       :formats [:json-kw]))
+                       {:formats [:json-kw]
+                        :charset get-or-default-charset}))
 
 (def restful-echo-yaml
   (wrap-restful-format (fn [req] (assoc req :body (vals (:body-params req))))
-                       :formats [:yaml-kw]))
+                       {:formats [:yaml-kw]
+                        :charset get-or-default-charset}))
 
 (deftest format-json-prettily-from-wrap-restful-format
   ;; like format-response-test/format-json-prettily but starting from higher in the call stack
   (let [body {:foo "bar"}
         req {:body body}
-        resp ((wrap-restful-format identity :formats [:json-kw]
-                                            :response-options {:json-kw {:pretty true}})
+        resp ((wrap-restful-format identity {:formats [:json-kw]
+                                             :response-options {:json-kw {:pretty true}}
+                                             :charset get-or-default-charset})
                req)]
     (is (.contains (-> resp :body slurp) "\n "))))
 


### PR DESCRIPTION
Fixes #74 

If `:charset get-or-default-charset` option is provided, r-m-f will work even without icu4j dependency.

Ping @jimpil

During testing these changes, I found out there there wasn't a single test testing charset detection, and that it looks like charset detection has been broken previously. `available-charsets` lists the charset names in lower-case while icu4j returns name upper-case, so detection has always returned `nil`...) Because of this, I'm now considering if we could just default to no-detection and no-icu and provide separate namespace with guess-charset function. I need to investigate how long the detection has been broken.